### PR TITLE
ci: use direct Workload Identity federation instead of service account for deploy Cloud Functions

### DIFF
--- a/.github/workflows/cd_api-develop.yml
+++ b/.github/workflows/cd_api-develop.yml
@@ -32,8 +32,8 @@ jobs:
         uses: google-github-actions/auth@v2
         id: 'auth'
         with:
+          project_id: 'colomney-my-pet-melody-dev'
           workload_identity_provider: ${{ secrets.DEPLOY_FUNCTIONS_WORKLOAD_IDENTITY_PROVIDER_DEV }}
-          service_account: ${{ secrets.DEPLOY_FUNCTIONS_SERVICE_ACCOUNT_MAIL_DEV }}
       - name: Deploy detect Functions to Google Cloud
         uses: google-github-actions/deploy-cloud-functions@v2
         with:

--- a/.github/workflows/cd_api-production.yml
+++ b/.github/workflows/cd_api-production.yml
@@ -32,8 +32,8 @@ jobs:
         uses: google-github-actions/auth@v2
         id: 'auth'
         with:
+          project_id: 'colomney-my-pet-melody'
           workload_identity_provider: ${{ secrets.DEPLOY_FUNCTIONS_WORKLOAD_IDENTITY_PROVIDER_PROD }}
-          service_account: ${{ secrets.DEPLOY_FUNCTIONS_SERVICE_ACCOUNT_MAIL_PROD }}
       - name: Deploy detect Functions to Google Cloud
         uses: google-github-actions/deploy-cloud-functions@v2
         with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Chores**
	- Updated deployment configurations for both development and production environments.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->