### PR TITLE
dev: update Renovate range strategy to pin

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,59 +11,59 @@ environment:
   flutter: ">=3.19.5"
 
 dependencies:
-  audioplayers: 6.0.0
-  chewie: 1.8.1
-  cloud_firestore: 4.16.1
-  collection: 1.18.0
-  cross_file: 0.3.4+1
-  cupertino_icons: 1.0.8
-  device_info_plus: 10.1.0
-  dio: 5.4.3
-  ffmpeg_kit_flutter: 6.0.3
-  file_picker: 8.0.0+1
-  firebase_analytics: 10.10.2
-  firebase_auth: 4.19.2
-  firebase_core: 2.30.0
-  firebase_crashlytics: 3.5.1
-  firebase_messaging: 14.8.1
-  firebase_remote_config: 4.4.1
-  firebase_storage: 11.7.1
+  audioplayers: ^6.0.0
+  chewie: ^1.8.1
+  cloud_firestore: ^4.16.1
+  collection: ^1.18.0
+  cross_file: ^0.3.4+1
+  cupertino_icons: ^1.0.8
+  device_info_plus: ^10.1.0
+  dio: ^5.4.3
+  ffmpeg_kit_flutter: ^6.0.3
+  file_picker: ^8.0.0+1
+  firebase_analytics: ^10.10.2
+  firebase_auth: ^4.19.2
+  firebase_core: ^2.30.0
+  firebase_crashlytics: ^3.5.1
+  firebase_messaging: ^14.8.1
+  firebase_remote_config: ^4.4.1
+  firebase_storage: ^11.7.1
   flutter:
     sdk: flutter
-  flutter_local_notifications: 17.0.1
+  flutter_local_notifications: ^17.0.1
   flutter_localizations:
     sdk: flutter
-  flutter_riverpod: 2.5.1
-  flutter_svg: 2.0.10+1
-  font_awesome_flutter: 10.7.0
-  freezed_annotation: 2.4.1
-  google_sign_in: 6.2.1
-  in_app_review: 2.0.9
-  intl: 0.18.1
-  package_info_plus: 7.0.0
-  path: 1.9.0
-  path_provider: 2.1.3
-  purchases_flutter: 6.26.0
-  rxdart: 0.27.7
-  share_plus: 8.0.3
-  shared_preferences: 2.2.3
-  skeletons: 0.0.3
-  twitter_login: 4.4.2
-  url_launcher: 6.2.6
-  video_player: 2.8.6
-  video_thumbnail: 0.5.3
-  video_trimmer: 3.0.1
+  flutter_riverpod: ^2.5.1
+  flutter_svg: ^2.0.10+1
+  font_awesome_flutter: ^10.7.0
+  freezed_annotation: ^2.4.1
+  google_sign_in: ^6.2.1
+  in_app_review: ^2.0.9
+  intl: ^0.18.1
+  package_info_plus: ^7.0.0
+  path: ^1.9.0
+  path_provider: ^2.1.3
+  purchases_flutter: ^6.26.0
+  rxdart: ^0.27.7
+  share_plus: ^8.0.3
+  shared_preferences: ^2.2.3
+  skeletons: ^0.0.3
+  twitter_login: ^4.4.2
+  url_launcher: ^6.2.6
+  video_player: ^2.8.6
+  video_thumbnail: ^0.5.3
+  video_trimmer: ^3.0.1
 
 dev_dependencies:
-  build_runner: 2.4.9
-  cider: 0.2.7
+  build_runner: ^2.4.9
+  cider: ^0.2.7
   flutter_test:
     sdk: flutter
-  freezed: 2.5.2
-  json_serializable: 6.7.1
-  mocktail: 1.0.3
-  pedantic_mono: 1.26.0
-  watcher: 1.1.0
+  freezed: ^2.5.2
+  json_serializable: ^6.7.1
+  mocktail: ^1.0.3
+  pedantic_mono: ^1.26.0
+  watcher: ^1.1.0
 
 flutter:
   uses-material-design: true

--- a/renovate.json
+++ b/renovate.json
@@ -42,5 +42,6 @@
     }
   ],
   "prConcurrentLimit": 1,
+  "rangeStrategy": "pin",
   "semanticCommitType": "build"
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
    - Updated dependency versions in `pubspec.yaml` to ensure compatibility with newer versions by using the caret (`^`) symbol for version ranges.
    - Configured dependency management settings in `renovate.json` by adding the `"rangeStrategy": "pin"` setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->