### PR TITLE
dev: add reviewer for PRs by Renovate and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,8 @@ updates:
   - package-ecosystem: "bundler"
     directory: "/"
     open-pull-requests-limit: 1
+    reviewers:
+      - "shotaIDE"
     schedule:
       interval: "daily"
       time: "03:00"
@@ -10,6 +12,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     open-pull-requests-limit: 1
+    reviewers:
+      - "shotaIDE"
     schedule:
       interval: "daily"
       time: "04:00"
@@ -17,6 +21,8 @@ updates:
   - package-ecosystem: "gradle"
     directory: "/android/"
     open-pull-requests-limit: 1
+    reviewers:
+      - "shotaIDE"
     schedule:
       interval: "daily"
       time: "05:00"
@@ -24,6 +30,8 @@ updates:
   - package-ecosystem: "pip"
     directory: "/function/"
     open-pull-requests-limit: 1
+    reviewers:
+      - "shotaIDE"
     schedule:
       interval: "daily"
       time: "06:00"

--- a/renovate.json
+++ b/renovate.json
@@ -45,5 +45,6 @@
     }
   ],
   "prConcurrentLimit": 1,
-  "rangeStrategy": "pin"
+  "rangeStrategy": "pin",
+  "reviewers": ["shotaIDE"]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated the configuration to assign default reviewers for code changes.
	- Scheduled daily updates for package ecosystems with specific times in the `Asia/Tokyo` timezone.
	- Added a new key-value pair for reviewers in the `renovate.json` file.
	- Modified the `rangeStrategy` in `renovate.json` to include the new `"reviewers"` field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->