### PR TITLE
fix: correct Japanese labels on select trimmed sound screen

### DIFF
--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -67,9 +67,9 @@
   "convertingVideoDescription": "動画を変換しています。\nこれには数分かかる場合があります",
   "searchingSoundDescription": "動画の中から鳴き声を探しています。\nこれには数分かかる場合があります",
   "step4Of5": "STEP 4/5",
-  "selectMeow": "Select a meow",
+  "selectMeow": "鳴き声を選ぼう",
   "trimManually": "自分でトリミングする",
-  "selectNThMeow": "Select the {index}-th meow",
+  "selectNThMeow": "{index}番目の鳴き声を選択する",
   "@selectNThMeow": {
     "placeholders": {
       "index": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated Japanese translations for user interface elements related to selecting and trimming video features, enhancing clarity and usability for Japanese-speaking users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->