### PR TITLE
ci: ignore v3 updates for google-github-actions/deploy-cloud-functions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
       timezone: "Asia/Tokyo"
   - package-ecosystem: "github-actions"
     directory: "/"
+    ignore:
+      - dependency-name: "google-github-actions/deploy-cloud-functions"
+        # For functions v1, ignore all updates greater than or equal to version 3
+        versions: ">= 3"
     open-pull-requests-limit: 1
     reviewers:
       - "shotaIDE"

--- a/.github/workflows/cd_api-develop.yml
+++ b/.github/workflows/cd_api-develop.yml
@@ -35,7 +35,7 @@ jobs:
           service_account: ${{ secrets.DEPLOY_FUNCTIONS_SERVICE_ACCOUNT_EMAIL_DEV }}
           workload_identity_provider: ${{ secrets.DEPLOY_FUNCTIONS_WORKLOAD_IDENTITY_PROVIDER_DEV }}
       - name: Deploy detect Functions to Google Cloud
-        uses: google-github-actions/deploy-cloud-functions@v3
+        uses: google-github-actions/deploy-cloud-functions@v2
         with:
           name: 'detect'
           runtime: 'python310'
@@ -48,7 +48,7 @@ jobs:
           max_instances: 1
           deploy_timeout: 600
       - name: Deploy submit Functions to Google Cloud
-        uses: google-github-actions/deploy-cloud-functions@v3
+        uses: google-github-actions/deploy-cloud-functions@v2
         with:
           name: 'submit'
           runtime: 'python310'
@@ -61,7 +61,7 @@ jobs:
           max_instances: 1
           deploy_timeout: 600
       - name: Deploy piece Functions to Google Cloud
-        uses: google-github-actions/deploy-cloud-functions@v3
+        uses: google-github-actions/deploy-cloud-functions@v2
         with:
           name: 'piece'
           runtime: 'python310'

--- a/.github/workflows/cd_api-production.yml
+++ b/.github/workflows/cd_api-production.yml
@@ -35,7 +35,7 @@ jobs:
           service_account: ${{ secrets.DEPLOY_FUNCTIONS_SERVICE_ACCOUNT_EMAIL_PROD }}
           workload_identity_provider: ${{ secrets.DEPLOY_FUNCTIONS_WORKLOAD_IDENTITY_PROVIDER_PROD }}
       - name: Deploy detect Functions to Google Cloud
-        uses: google-github-actions/deploy-cloud-functions@v3
+        uses: google-github-actions/deploy-cloud-functions@v2
         with:
           name: 'detect'
           runtime: 'python310'
@@ -48,7 +48,7 @@ jobs:
           max_instances: 1
           deploy_timeout: 600
       - name: Deploy submit Functions to Google Cloud
-        uses: google-github-actions/deploy-cloud-functions@v3
+        uses: google-github-actions/deploy-cloud-functions@v2
         with:
           name: 'submit'
           runtime: 'python310'
@@ -61,7 +61,7 @@ jobs:
           max_instances: 1
           deploy_timeout: 600
       - name: Deploy piece Functions to Google Cloud
-        uses: google-github-actions/deploy-cloud-functions@v3
+        uses: google-github-actions/deploy-cloud-functions@v2
         with:
           name: 'piece'
           runtime: 'python310'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Configured Dependabot to ignore updates for `google-github-actions/deploy-cloud-functions` versions >= 3.
  - Downgraded `google-github-actions/deploy-cloud-functions` from version 3 to version 2 in deployment workflows for both development and production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->