### PR TITLE
ci: disable updating Dart by Renovate

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1603,5 +1603,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: "3.3.4"
+  dart: ">=3.3.0 <4.0.0"
   flutter: ">=3.19.6"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: "none"
 version: 1.0.24+54
 
 environment:
-  sdk: "3.3.4"
+  sdk: ">=3.3.0 <4.0.0"
   # Specify for inference of dependabot
   flutter: 3.19.6
 

--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,11 @@
     },
     {
       "matchManagers": ["pub"],
+      "matchPackageNames": ["dart"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["pub"],
       "addLabels": ["dart"],
       "automerge": true
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated SDK version constraint to support a broader range of versions (`>=3.3.0 <4.0.0`).
  - Disabled specific Dart package management configuration in `renovate.json`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->