### PR TITLE
fix: app display name for iOS

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>My Pet Melody</string>
+	<string>うちのコメロディー</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -15,7 +15,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>MyPetMelody</string>
+	<string>うちメロ</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
@@ -72,8 +72,8 @@
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>You can set thumbnails of your pieces.</string>
+	<string>作品のサムネイルを設定するために必要です。</string>
 	<key>NSCameraUsageDescription</key>
-	<string>You can add meows to your pieces.</string>
+	<string>作品に鳴き声を入れるために必要です。</string>
 </dict>
 </plist>

--- a/ios/Runner/Localizable.xcstrings
+++ b/ios/Runner/Localizable.xcstrings
@@ -3,10 +3,11 @@
   "strings" : {
     "CFBundleDisplayName" : {
       "comment" : "Bundle display name",
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "My Pet Melody"
           }
         },
@@ -20,6 +21,7 @@
     },
     "CFBundleName" : {
       "comment" : "Bundle name",
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -37,6 +39,7 @@
     },
     "NSCameraUsageDescription" : {
       "comment" : "Privacy - Camera Usage Description",
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -54,6 +57,7 @@
     },
     "NSPhotoLibraryUsageDescription" : {
       "comment" : "Privacy - Photo Library Usage Description",
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -93,7 +93,7 @@ platform :ios do
 
     app_store_connect_api_key_path = 'fastlane/app-store-connect-api-key.p8'
 
-    lane_context[SharedValues::IPA_OUTPUT_PATH] = 'build/ios/ipa/MyPetMelody.ipa'
+    lane_context[SharedValues::IPA_OUTPUT_PATH] = 'build/ios/ipa/うちメロ.ipa'
 
     api_key = app_store_connect_api_key(
       key_id: apple_api_key_id,
@@ -130,6 +130,6 @@ platform :ios do
       )
     end
 
-    lane_context[SharedValues::IPA_OUTPUT_PATH] = 'build/ios/ipa/MyPetMelody.ipa'
+    lane_context[SharedValues::IPA_OUTPUT_PATH] = 'build/ios/ipa/うちメロ.ipa'
   end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Localized app display names and descriptions to Japanese for a more tailored user experience.
  - Updated app name in the build output path to reflect the Japanese localization.

- **Localization**
  - Translated various user-facing strings to Japanese, enhancing accessibility for Japanese-speaking users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->