### PR TITLE
fix: brush up Terraform definitions with existing Firebase projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ GoogleService-Info.plist
 /fastlane/report.xml
 /fastlane/spreadsheet-service-account-key.json
 /function/samples/
+/function2
 /infra/google-cloud-credentials.json
 /ios/firebase_app_id_file.json
 /ios/Flutter/DartDefines.xcconfig

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ GoogleService-Info.plist
 /fastlane/report.xml
 /fastlane/spreadsheet-service-account-key.json
 /function/samples/
-/function2
 /infra/google-cloud-credentials.json
 /ios/firebase_app_id_file.json
 /ios/Flutter/DartDefines.xcconfig

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,9 +31,6 @@
     "editor.formatOnSave": true,
     "editor.tabSize": 2
   },
-  "[terraform]": {
-    "editor.formatOnSave": true
-  },
   "[yaml]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,

--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,3 +1,5 @@
+/function.zip
+
 # Local .terraform directories
 **/.terraform/*
 

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,23 +1,41 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/google" {
-  version = "5.8.0"
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.4.2"
   hashes = [
-    "h1:PY8Uno1SdOlR194gxIbwU9QowioRJZCos2oJ3VWLwXI=",
-    "h1:R1ZSQbkSy9bnZj5flhx/u+CMSxXFr43uhkn46R5zeQY=",
-    "zh:1e9114e4b6c9886ee37dfb7a2fa5776f2977df44f076fb2ca8d8015a19f2cd2b",
-    "zh:26e319b67f5accd643e9af8b3b9ab96f9f79c625d889d39cb3bca21749ce643f",
-    "zh:3e062a4a31d8a5a2c2cb9b3c6f606a7e45a726b5f160ebca01c9f4aca8eff91e",
-    "zh:5f287a4b46731eae42d56a4ab1b134a6107d1c5faa658d3024c93bdf6cfbd6f0",
-    "zh:646c5ed8f6bda9ad130c1b2441e0b51ea3a59d20d1cc7539efcb562c92cf29c7",
-    "zh:7ecba80bce8c4322def7e72003058de99af653ede72ececb8254a3d5631ad876",
-    "zh:b50a9fcee3f2b37e36052903a4e951f5836c31ef9f76af79a6de7f59c303ae77",
-    "zh:b793d50456b7d2a8902b1c608437c92453ed260d8404c37aebc6b836b31e6a64",
-    "zh:c6cffdc8edac730066c7022d4e94f44a20ae89af4b50a226e1e3ebcb98fe0399",
-    "zh:cdf74d540408d0ef178e18dbc68c9a40751571ef116dabdac097d2b80bbebe8c",
+    "h1:WfIjVbYA9s/uN2FwhGoiffT7CLFydy7MT1waFbt9YrY=",
+    "zh:08faed7c9f42d82bc3d406d0d9d4971e2d1c2d34eae268ad211b8aca57b7f758",
+    "zh:3564112ed2d097d7e0672378044a69b06642c326f6f1584d81c7cdd32ebf3a08",
+    "zh:53cd9afd223c15828c1916e68cb728d2be1cbccb9545568d6c2b122d0bac5102",
+    "zh:5ae4e41e3a1ce9d40b6458218a85bbde44f21723943982bca4a3b8bb7c103670",
+    "zh:5b65499218b315b96e95c5d3463ea6d7c66245b59461217c99eaa1611891cd2c",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7f45b35a8330bebd184c2545a41782ff58240ed6ba947274d9881dd5da44b02e",
+    "zh:87e67891033214e55cfead1391d68e6a3bf37993b7607753237e82aa3250bb71",
+    "zh:de3590d14037ad81fc5cedf7cfa44614a92452d7b39676289b704a962050bc5e",
+    "zh:e7e6f2ea567f2dbb3baa81c6203be69f9cd6aeeb01204fd93e3cf181e099b610",
+    "zh:fd24d03c89a7702628c2e5a3c732c0dede56fa75a08da4a1efe17b5f881c88e2",
+    "zh:febf4b7b5f3ff2adff0573ef6361f09b6638105111644bdebc0e4f575373935f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "5.32.0"
+  hashes = [
+    "h1:1uJLcbiL1Jv3tbwA+Sonm/I8wGldRwjcoGb8Db4aJAA=",
+    "zh:0cde8353183f6c700be6c50e5d41e7950aa081a542747cb7415c262c1e2665b6",
+    "zh:1e1db2d58e412142698d33f87c8a56f3146e028d11f59269b079186202d27052",
+    "zh:2a4b93110be8a7f25c351ccf186a431b59131d5a3d12159b8e3c9d5c3e3d77f0",
+    "zh:67f468743028f32cda193898d4d42ddfb7e0c820a4047243d5c6bf17ba3bc394",
+    "zh:7127b2ea83d034ce7fc1f87f4ba14ed42091a814ed08be0655f06a7a12378e0c",
+    "zh:9184dc2b092b49dd997c409fa11f307d1d839eb416671f81385527d9e0747adb",
+    "zh:9b7db4bfeac9131ad2829c0bab66cf54a526ce8e538775f3292d0294ce9a7b79",
+    "zh:a2a9d9f18ab9dfe1c27f74408a0c426c7c2563eec50c37bc18e14930888eb359",
+    "zh:ad080f92382ae4aa6ffbc73cbe7045ff741db0e35fdb02a37248d1f776190468",
+    "zh:d71a9ce6044cabf3cc60fd1c3af4fee2e5e57059658a66bdb6b303853c595241",
+    "zh:f46314fe3427a386e4a7599be48c5a419960aba1d7681f82d8a26056b9ca468c",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-    "zh:fa141144675905e3c74f80f211e6ebd89d7658b2692305e653fc432ebcaf0a7c",
   ]
 }
 

--- a/infra/.vscode/settings.json
+++ b/infra/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "editor.tabSize": 2
+  },
+  "[jsonc]": {
+    "editor.formatOnSave": true,
+    "editor.tabSize": 2
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[terraform]": {
+    "editor.formatOnSave": true
+  }
+}

--- a/infra/auth.tf
+++ b/infra/auth.tf
@@ -4,29 +4,10 @@ resource "google_identity_platform_config" "auth" {
   provider = google-beta
   project  = google_project.default.project_id
 
-  # For example, you can configure to auto-delete Anonymous users.
-  autodelete_anonymous_users = true
+  autodelete_anonymous_users = false
 
   # Wait for identitytoolkit.googleapis.com to be enabled before initializing Authentication.
   depends_on = [
     google_project_service.default,
-  ]
-}
-
-# Adds more configurations, like for the email/password sign-in provider.
-resource "google_identity_platform_project_default_config" "auth" {
-  provider = google-beta
-  project  = google_project.default.project_id
-  sign_in {
-    allow_duplicate_emails = false
-
-    anonymous {
-      enabled = true
-    }
-  }
-
-  # Wait for Authentication to be initialized before enabling email/password.
-  depends_on = [
-    google_identity_platform_config.auth
   ]
 }

--- a/infra/auth.tf
+++ b/infra/auth.tf
@@ -11,3 +11,19 @@ resource "google_identity_platform_config" "auth" {
     google_project_service.default,
   ]
 }
+
+resource "google_identity_platform_project_default_config" "auth" {
+  provider = google-beta
+  project  = google_project.default.project_id
+  sign_in {
+    allow_duplicate_emails = false
+
+    anonymous {
+      enabled = true
+    }
+  }
+
+  depends_on = [
+    google_identity_platform_config.auth
+  ]
+}

--- a/infra/auth.tf
+++ b/infra/auth.tf
@@ -1,17 +1,8 @@
 resource "google_identity_platform_config" "auth" {
   provider = google-beta
   project  = google_project.default.project_id
-
   autodelete_anonymous_users = false
 
-  depends_on = [
-    google_project_service.default,
-  ]
-}
-
-resource "google_identity_platform_project_default_config" "auth" {
-  provider = google-beta
-  project  = google_project.default.project_id
   sign_in {
     allow_duplicate_emails = false
 
@@ -21,6 +12,6 @@ resource "google_identity_platform_project_default_config" "auth" {
   }
 
   depends_on = [
-    google_identity_platform_config.auth
+    google_project_service.default,
   ]
 }

--- a/infra/auth.tf
+++ b/infra/auth.tf
@@ -1,12 +1,9 @@
-# Creates an Identity Platform config.
-# Also enables Firebase Authentication with Identity Platform in the project if not.
 resource "google_identity_platform_config" "auth" {
   provider = google-beta
   project  = google_project.default.project_id
 
   autodelete_anonymous_users = false
 
-  # Wait for identitytoolkit.googleapis.com to be enabled before initializing Authentication.
   depends_on = [
     google_project_service.default,
   ]

--- a/infra/database.tf
+++ b/infra/database.tf
@@ -3,8 +3,8 @@ resource "google_firestore_database" "default" {
   name                    = "(default)"
   location_id             = var.google_project_location
   type                    = "FIRESTORE_NATIVE"
-  delete_protection_state = "DELETE_PROTECTION_ENABLED"
-  deletion_policy         = "DELETE"
+  delete_protection_state = "DELETE_PROTECTION_DISABLED"
+  deletion_policy         = "ABANDON"
 }
 
 # Creates a ruleset of Firestore Security Rules from a local file.

--- a/infra/database.tf
+++ b/infra/database.tf
@@ -7,7 +7,6 @@ resource "google_firestore_database" "default" {
   deletion_policy         = "ABANDON"
 }
 
-# Creates a ruleset of Firestore Security Rules from a local file.
 resource "google_firebaserules_ruleset" "firestore" {
   provider = google-beta
   project  = google_project.default.project_id
@@ -18,20 +17,17 @@ resource "google_firebaserules_ruleset" "firestore" {
     }
   }
 
-  # Wait for Firestore to be provisioned before creating this ruleset.
   depends_on = [
     google_firestore_database.default,
   ]
 }
 
-# Releases the ruleset for the Firestore instance.
 resource "google_firebaserules_release" "firestore" {
   provider     = google-beta
-  name         = "cloud.firestore" # must be cloud.firestore
+  name         = "cloud.firestore"
   ruleset_name = google_firebaserules_ruleset.firestore.name
   project      = google_project.default.project_id
 
-  # Wait for Firestore to be provisioned before releasing the ruleset.
   depends_on = [
     google_firestore_database.default,
   ]

--- a/infra/function.tf
+++ b/infra/function.tf
@@ -70,8 +70,10 @@ resource "google_storage_bucket_object" "functions_src" {
 }
 
 resource "google_cloudfunctions_function" "detect" {
+  project                      = google_project.default.project_id
   name                         = "detect"
   runtime                      = local.runtime
+  region                       = var.google_project_location
   source_archive_bucket        = google_storage_bucket.default.name
   source_archive_object        = google_storage_bucket_object.functions_src.name
   trigger_http                 = true
@@ -98,8 +100,10 @@ resource "google_cloudfunctions_function_iam_member" "detect_invoker" {
 }
 
 resource "google_cloudfunctions_function" "submit" {
+  project                      = google_project.default.project_id
   name                         = "submit"
   runtime                      = local.runtime
+  region                       = var.google_project_location
   source_archive_bucket        = google_storage_bucket.default.name
   source_archive_object        = google_storage_bucket_object.functions_src.name
   trigger_http                 = true
@@ -126,8 +130,10 @@ resource "google_cloudfunctions_function_iam_member" "submit_invoker" {
 }
 
 resource "google_cloudfunctions_function" "piece" {
+  project                      = google_project.default.project_id
   name                         = "piece"
   runtime                      = local.runtime
+  region                       = var.google_project_location
   source_archive_bucket        = google_storage_bucket.default.name
   source_archive_object        = google_storage_bucket_object.functions_src.name
   trigger_http                 = true

--- a/infra/function.tf
+++ b/infra/function.tf
@@ -55,7 +55,7 @@ locals {
 
 data "archive_file" "functions_src" {
   type        = "zip"
-  source_dir  = "../function2"
+  source_dir  = "../function"
   output_path = "./function.zip"
 }
 

--- a/infra/function.tf
+++ b/infra/function.tf
@@ -61,7 +61,7 @@ data "archive_file" "functions_src" {
 
 resource "google_storage_bucket_object" "functions_src" {
   name   = "functions/src_${data.archive_file.functions_src.output_md5}.zip"
-  bucket = google_storage_bucket.default.name
+  bucket = google_storage_bucket.deploy.name
   source = data.archive_file.functions_src.output_path
 
   depends_on = [
@@ -74,7 +74,7 @@ resource "google_cloudfunctions_function" "detect" {
   name                         = "detect"
   runtime                      = local.runtime
   region                       = var.google_project_location
-  source_archive_bucket        = google_storage_bucket.default.name
+  source_archive_bucket        = google_storage_bucket.deploy.name
   source_archive_object        = google_storage_bucket_object.functions_src.name
   trigger_http                 = true
   available_memory_mb          = 2048
@@ -104,7 +104,7 @@ resource "google_cloudfunctions_function" "submit" {
   name                         = "submit"
   runtime                      = local.runtime
   region                       = var.google_project_location
-  source_archive_bucket        = google_storage_bucket.default.name
+  source_archive_bucket        = google_storage_bucket.deploy.name
   source_archive_object        = google_storage_bucket_object.functions_src.name
   trigger_http                 = true
   available_memory_mb          = 1024
@@ -134,7 +134,7 @@ resource "google_cloudfunctions_function" "piece" {
   name                         = "piece"
   runtime                      = local.runtime
   region                       = var.google_project_location
-  source_archive_bucket        = google_storage_bucket.default.name
+  source_archive_bucket        = google_storage_bucket.deploy.name
   source_archive_object        = google_storage_bucket_object.functions_src.name
   trigger_http                 = true
   available_memory_mb          = 1024

--- a/infra/function.tf
+++ b/infra/function.tf
@@ -1,0 +1,60 @@
+data "archive_file" "functions_src" {
+  type        = "zip"
+  source_dir  = "../function"
+  output_path = "./function.zip"
+}
+
+resource "google_storage_bucket_object" "functions_src" {
+  name   = "functions/src_${data.archive_file.functions_src.output_md5}.zip"
+  bucket = google_storage_bucket.default.name
+  source = data.archive_file.functions_src.output_path
+
+  depends_on = [
+    google_firebase_project.default,
+  ]
+}
+
+resource "google_cloudfunctions_function" "detect" {
+  name                         = "detect"
+  runtime                      = "python310"
+  source_archive_bucket        = google_storage_bucket.default.name
+  source_archive_object        = google_storage_bucket_object.functions_src.name
+  trigger_http                 = true
+  available_memory_mb          = 2048
+  timeout                      = 60
+  entry_point                  = "detect"
+  docker_registry              = "CONTAINER_REGISTRY"
+  https_trigger_security_level = "SECURE_OPTIONAL"
+  max_instances                = 1
+  min_instances                = 0
+}
+
+resource "google_cloudfunctions_function" "submit" {
+  name                         = "piece"
+  runtime                      = "python310"
+  source_archive_bucket        = google_storage_bucket.default.name
+  source_archive_object        = google_storage_bucket_object.functions_src.name
+  trigger_http                 = true
+  available_memory_mb          = 1024
+  timeout                      = 60
+  entry_point                  = "piece"
+  docker_registry              = "CONTAINER_REGISTRY"
+  https_trigger_security_level = "SECURE_OPTIONAL"
+  max_instances                = 1
+  min_instances                = 0
+}
+
+resource "google_cloudfunctions_function" "piece" {
+  name                         = "piece"
+  runtime                      = "python310"
+  source_archive_bucket        = google_storage_bucket.default.name
+  source_archive_object        = google_storage_bucket_object.functions_src.name
+  trigger_http                 = true
+  available_memory_mb          = 1024
+  timeout                      = 60
+  entry_point                  = "piece"
+  docker_registry              = "CONTAINER_REGISTRY"
+  https_trigger_security_level = "SECURE_OPTIONAL"
+  max_instances                = 1
+  min_instances                = 0
+}

--- a/infra/function.tf
+++ b/infra/function.tf
@@ -92,6 +92,15 @@ resource "google_cloudfunctions_function" "detect" {
   }
 }
 
+resource "google_cloudfunctions_function_iam_member" "invoker" {
+  project        = google_cloudfunctions_function.detect.project
+  region         = google_cloudfunctions_function.detect.region
+  cloud_function = google_cloudfunctions_function.detect.name
+
+  role   = "roles/cloudfunctions.invoker"
+  member = "allUsers"
+}
+
 resource "google_cloudfunctions_function" "submit" {
   name                         = "submit"
   runtime                      = local.runtime
@@ -113,6 +122,15 @@ resource "google_cloudfunctions_function" "submit" {
   }
 }
 
+resource "google_cloudfunctions_function_iam_member" "invoker" {
+  project        = google_cloudfunctions_function.submit.project
+  region         = google_cloudfunctions_function.submit.region
+  cloud_function = google_cloudfunctions_function.submit.name
+
+  role   = "roles/cloudfunctions.invoker"
+  member = "allUsers"
+}
+
 resource "google_cloudfunctions_function" "piece" {
   name                         = "piece"
   runtime                      = local.runtime
@@ -132,4 +150,13 @@ resource "google_cloudfunctions_function" "piece" {
   timeouts {
     create = local.timeout
   }
+}
+
+resource "google_cloudfunctions_function_iam_member" "invoker" {
+  project        = google_cloudfunctions_function.piece.project
+  region         = google_cloudfunctions_function.piece.region
+  cloud_function = google_cloudfunctions_function.piece.name
+
+  role   = "roles/cloudfunctions.invoker"
+  member = "allUsers"
 }

--- a/infra/function.tf
+++ b/infra/function.tf
@@ -1,8 +1,57 @@
+variable "firebase_admin_key_file_name" {
+  type        = string
+  default     = "firebase-serviceAccountKey_dev.json"
+  description = "Service account key JSON file name for Firebase admin."
+}
+
+variable "google_application_credentials" {
+  type        = string
+  default     = "cloud-tasks-serviceAccountKey_dev.json"
+  description = "Service account key JSON file name for Cloud tasks."
+}
+
+variable "revenue_cat_public_apple_api_key" {
+  type        = string
+  default     = ""
+  description = "Public Apple API key for RevenueCat."
+}
+
+variable "revenue_cat_public_google_api_key" {
+  type        = string
+  default     = ""
+  description = "Public Google API key for RevenueCat."
+}
+
+variable "feature_eliminate_waiting_time_to_generate" {
+  type        = string
+  default     = "true"
+  description = "Is enabled the feature to eliminate waiting time to generate pieces depends on Premium Plan."
+}
+
+variable "waiting_time_seconds_to_generate" {
+  type        = string
+  default     = "300"
+  description = "Waiting time seconds to generate pieces."
+}
+
 locals {
   runtime = "python310"
   docker_registry = "CONTAINER_REGISTRY"
   https_trigger_security_level = "SECURE_OPTIONAL"
   timeout = "10m"
+  environment_variables = {
+    "FIREBASE_ADMIN_KEY_FILE_NAME" = var.firebase_admin_key_file_name
+    "FIREBASE_STORAGE_BUCKET_NAME" = google_storage_bucket.default.name
+    "FIREBASE_FUNCTIONS_API_ORIGIN" = "https://${var.google_project_location}-${google_project.default.project_id}.cloudfunctions.net"
+    "GOOGLE_APPLICATION_CREDENTIALS" = var.google_application_credentials
+    "GOOGLE_CLOUD_PROJECT_ID" = google_project.default.project_id
+    "GOOGLE_CLOUD_TASKS_LOCATION" = var.google_project_location
+    "GOOGLE_CLOUD_TASKS_QUEUE_ID" = google_cloud_tasks_queue.advanced_configuration.name
+    "REVENUE_CAT_PUBLIC_APPLE_API_KEY" = var.revenue_cat_public_apple_api_key
+    "REVENUE_CAT_PUBLIC_GOOGLE_API_KEY" = var.revenue_cat_public_google_api_key
+    "FEATURE_ELIMINATE_WAITING_TIME_TO_GENERATE" = var.feature_eliminate_waiting_time_to_generate
+    "WAITING_TIME_SECONDS_TO_GENERATE" = var.waiting_time_seconds_to_generate
+  }
 }
 
 data "archive_file" "functions_src" {
@@ -34,6 +83,7 @@ resource "google_cloudfunctions_function" "detect" {
   https_trigger_security_level = local.https_trigger_security_level
   max_instances                = 1
   min_instances                = 0
+  environment_variables = local.environment_variables
 
   timeouts {
     create = local.timeout
@@ -53,6 +103,7 @@ resource "google_cloudfunctions_function" "submit" {
   https_trigger_security_level = local.https_trigger_security_level
   max_instances                = 1
   min_instances                = 0
+  environment_variables = local.environment_variables
 
   timeouts {
     create = local.timeout
@@ -72,6 +123,7 @@ resource "google_cloudfunctions_function" "piece" {
   https_trigger_security_level = local.https_trigger_security_level
   max_instances                = 1
   min_instances                = 0
+  environment_variables = local.environment_variables
 
   timeouts {
     create = local.timeout

--- a/infra/function.tf
+++ b/infra/function.tf
@@ -38,7 +38,7 @@ locals {
   runtime = "python310"
   docker_registry = "CONTAINER_REGISTRY"
   https_trigger_security_level = "SECURE_OPTIONAL"
-  timeout = "10m"
+  timeout = "20m"
   environment_variables = {
     "FIREBASE_ADMIN_KEY_FILE_NAME" = var.firebase_admin_key_file_name
     "FIREBASE_STORAGE_BUCKET_NAME" = google_storage_bucket.default.name

--- a/infra/function.tf
+++ b/infra/function.tf
@@ -40,7 +40,7 @@ locals {
   timeout = "20m"
   environment_variables = {
     "FIREBASE_ADMIN_KEY_FILE_NAME" = var.firebase_admin_key_file_name
-    "FIREBASE_STORAGE_BUCKET_NAME" = google_storage_bucket.default.name
+    "FIREBASE_STORAGE_BUCKET_NAME" = google_app_engine_application.default.default_bucket
     "FIREBASE_FUNCTIONS_API_ORIGIN" = "https://${var.google_project_location}-${google_project.default.project_id}.cloudfunctions.net"
     "GOOGLE_APPLICATION_CREDENTIALS" = var.google_application_credentials
     "GOOGLE_CLOUD_PROJECT_ID" = google_project.default.project_id

--- a/infra/function.tf
+++ b/infra/function.tf
@@ -45,7 +45,7 @@ locals {
     "GOOGLE_APPLICATION_CREDENTIALS" = var.google_application_credentials
     "GOOGLE_CLOUD_PROJECT_ID" = google_project.default.project_id
     "GOOGLE_CLOUD_TASKS_LOCATION" = var.google_project_location
-    "GOOGLE_CLOUD_TASKS_QUEUE_ID" = google_cloud_tasks_queue.advanced_configuration.name
+    "GOOGLE_CLOUD_TASKS_QUEUE_ID" = google_cloud_tasks_queue.default.name
     "REVENUE_CAT_PUBLIC_APPLE_API_KEY" = var.revenue_cat_public_apple_api_key
     "REVENUE_CAT_PUBLIC_GOOGLE_API_KEY" = var.revenue_cat_public_google_api_key
     "FEATURE_ELIMINATE_WAITING_TIME_TO_GENERATE" = var.feature_eliminate_waiting_time_to_generate

--- a/infra/function.tf
+++ b/infra/function.tf
@@ -38,6 +38,7 @@ locals {
   runtime = "python310"
   docker_registry = "CONTAINER_REGISTRY"
   https_trigger_security_level = "SECURE_OPTIONAL"
+  ingress_settings = "ALLOW_ALL"
   timeout = "20m"
   environment_variables = {
     "FIREBASE_ADMIN_KEY_FILE_NAME" = var.firebase_admin_key_file_name
@@ -81,6 +82,7 @@ resource "google_cloudfunctions_function" "detect" {
   entry_point                  = "detect"
   docker_registry              = local.docker_registry
   https_trigger_security_level = local.https_trigger_security_level
+  ingress_settings             = local.ingress_settings
   max_instances                = 1
   min_instances                = 0
   environment_variables = local.environment_variables
@@ -101,6 +103,7 @@ resource "google_cloudfunctions_function" "submit" {
   entry_point                  = "submit"
   docker_registry              = local.docker_registry
   https_trigger_security_level = local.https_trigger_security_level
+  ingress_settings             = local.ingress_settings
   max_instances                = 1
   min_instances                = 0
   environment_variables = local.environment_variables
@@ -121,6 +124,7 @@ resource "google_cloudfunctions_function" "piece" {
   entry_point                  = "piece"
   docker_registry              = local.docker_registry
   https_trigger_security_level = local.https_trigger_security_level
+  ingress_settings             = local.ingress_settings
   max_instances                = 1
   min_instances                = 0
   environment_variables = local.environment_variables

--- a/infra/function.tf
+++ b/infra/function.tf
@@ -37,8 +37,6 @@ variable "waiting_time_seconds_to_generate" {
 locals {
   runtime = "python310"
   docker_registry = "CONTAINER_REGISTRY"
-  https_trigger_security_level = "SECURE_OPTIONAL"
-  ingress_settings = "ALLOW_ALL"
   timeout = "20m"
   environment_variables = {
     "FIREBASE_ADMIN_KEY_FILE_NAME" = var.firebase_admin_key_file_name
@@ -81,8 +79,6 @@ resource "google_cloudfunctions_function" "detect" {
   timeout                      = 60
   entry_point                  = "detect"
   docker_registry              = local.docker_registry
-  https_trigger_security_level = local.https_trigger_security_level
-  ingress_settings             = local.ingress_settings
   max_instances                = 1
   min_instances                = 0
   environment_variables = local.environment_variables
@@ -92,7 +88,7 @@ resource "google_cloudfunctions_function" "detect" {
   }
 }
 
-resource "google_cloudfunctions_function_iam_member" "invoker" {
+resource "google_cloudfunctions_function_iam_member" "detect_invoker" {
   project        = google_cloudfunctions_function.detect.project
   region         = google_cloudfunctions_function.detect.region
   cloud_function = google_cloudfunctions_function.detect.name
@@ -111,8 +107,6 @@ resource "google_cloudfunctions_function" "submit" {
   timeout                      = 60
   entry_point                  = "submit"
   docker_registry              = local.docker_registry
-  https_trigger_security_level = local.https_trigger_security_level
-  ingress_settings             = local.ingress_settings
   max_instances                = 1
   min_instances                = 0
   environment_variables = local.environment_variables
@@ -122,7 +116,7 @@ resource "google_cloudfunctions_function" "submit" {
   }
 }
 
-resource "google_cloudfunctions_function_iam_member" "invoker" {
+resource "google_cloudfunctions_function_iam_member" "submit_invoker" {
   project        = google_cloudfunctions_function.submit.project
   region         = google_cloudfunctions_function.submit.region
   cloud_function = google_cloudfunctions_function.submit.name
@@ -141,8 +135,6 @@ resource "google_cloudfunctions_function" "piece" {
   timeout                      = 60
   entry_point                  = "piece"
   docker_registry              = local.docker_registry
-  https_trigger_security_level = local.https_trigger_security_level
-  ingress_settings             = local.ingress_settings
   max_instances                = 1
   min_instances                = 0
   environment_variables = local.environment_variables
@@ -152,7 +144,7 @@ resource "google_cloudfunctions_function" "piece" {
   }
 }
 
-resource "google_cloudfunctions_function_iam_member" "invoker" {
+resource "google_cloudfunctions_function_iam_member" "piece_invoker" {
   project        = google_cloudfunctions_function.piece.project
   region         = google_cloudfunctions_function.piece.region
   cloud_function = google_cloudfunctions_function.piece.name

--- a/infra/function.tf
+++ b/infra/function.tf
@@ -6,7 +6,7 @@ locals {
 
 data "archive_file" "functions_src" {
   type        = "zip"
-  source_dir  = "../function"
+  source_dir  = "../function2"
   output_path = "./function.zip"
 }
 

--- a/infra/function.tf
+++ b/infra/function.tf
@@ -1,3 +1,9 @@
+locals {
+  runtime = "python310"
+  docker_registry = "CONTAINER_REGISTRY"
+  https_trigger_security_level = "SECURE_OPTIONAL"
+}
+
 data "archive_file" "functions_src" {
   type        = "zip"
   source_dir  = "../function"
@@ -16,45 +22,45 @@ resource "google_storage_bucket_object" "functions_src" {
 
 resource "google_cloudfunctions_function" "detect" {
   name                         = "detect"
-  runtime                      = "python310"
+  runtime                      = local.runtime
   source_archive_bucket        = google_storage_bucket.default.name
   source_archive_object        = google_storage_bucket_object.functions_src.name
   trigger_http                 = true
   available_memory_mb          = 2048
   timeout                      = 60
   entry_point                  = "detect"
-  docker_registry              = "CONTAINER_REGISTRY"
-  https_trigger_security_level = "SECURE_OPTIONAL"
+  docker_registry              = local.docker_registry
+  https_trigger_security_level = local.https_trigger_security_level
   max_instances                = 1
   min_instances                = 0
 }
 
 resource "google_cloudfunctions_function" "submit" {
-  name                         = "piece"
-  runtime                      = "python310"
+  name                         = "submit"
+  runtime                      = local.runtime
   source_archive_bucket        = google_storage_bucket.default.name
   source_archive_object        = google_storage_bucket_object.functions_src.name
   trigger_http                 = true
   available_memory_mb          = 1024
   timeout                      = 60
-  entry_point                  = "piece"
-  docker_registry              = "CONTAINER_REGISTRY"
-  https_trigger_security_level = "SECURE_OPTIONAL"
+  entry_point                  = "submit"
+  docker_registry              = local.docker_registry
+  https_trigger_security_level = local.https_trigger_security_level
   max_instances                = 1
   min_instances                = 0
 }
 
 resource "google_cloudfunctions_function" "piece" {
   name                         = "piece"
-  runtime                      = "python310"
+  runtime                      = local.runtime
   source_archive_bucket        = google_storage_bucket.default.name
   source_archive_object        = google_storage_bucket_object.functions_src.name
   trigger_http                 = true
   available_memory_mb          = 1024
   timeout                      = 60
   entry_point                  = "piece"
-  docker_registry              = "CONTAINER_REGISTRY"
-  https_trigger_security_level = "SECURE_OPTIONAL"
+  docker_registry              = local.docker_registry
+  https_trigger_security_level = local.https_trigger_security_level
   max_instances                = 1
   min_instances                = 0
 }

--- a/infra/function.tf
+++ b/infra/function.tf
@@ -87,6 +87,7 @@ resource "google_cloudfunctions_function" "detect" {
 
   timeouts {
     create = local.timeout
+    update = local.timeout
   }
 }
 
@@ -117,6 +118,7 @@ resource "google_cloudfunctions_function" "submit" {
 
   timeouts {
     create = local.timeout
+    update = local.timeout
   }
 }
 
@@ -147,6 +149,7 @@ resource "google_cloudfunctions_function" "piece" {
 
   timeouts {
     create = local.timeout
+    update = local.timeout
   }
 }
 

--- a/infra/function.tf
+++ b/infra/function.tf
@@ -2,6 +2,7 @@ locals {
   runtime = "python310"
   docker_registry = "CONTAINER_REGISTRY"
   https_trigger_security_level = "SECURE_OPTIONAL"
+  timeout = "10m"
 }
 
 data "archive_file" "functions_src" {
@@ -33,6 +34,10 @@ resource "google_cloudfunctions_function" "detect" {
   https_trigger_security_level = local.https_trigger_security_level
   max_instances                = 1
   min_instances                = 0
+
+  timeouts {
+    create = local.timeout
+  }
 }
 
 resource "google_cloudfunctions_function" "submit" {
@@ -48,6 +53,10 @@ resource "google_cloudfunctions_function" "submit" {
   https_trigger_security_level = local.https_trigger_security_level
   max_instances                = 1
   min_instances                = 0
+
+  timeouts {
+    create = local.timeout
+  }
 }
 
 resource "google_cloudfunctions_function" "piece" {
@@ -63,4 +72,8 @@ resource "google_cloudfunctions_function" "piece" {
   https_trigger_security_level = local.https_trigger_security_level
   max_instances                = 1
   min_instances                = 0
+
+  timeouts {
+    create = local.timeout
+  }
 }

--- a/infra/import.tf
+++ b/infra/import.tf
@@ -106,3 +106,8 @@ import {
 # TODO: import to google_firebaserules_ruleset.storage
 
 # TODO: import to google_firebaserules_release.storage
+
+import {
+  id = "projects/${local.google_project_id}/locations/${var.google_project_location}/queues/${local.google_project_id}-service"
+  to = google_cloud_tasks_queue.default
+}

--- a/infra/import.tf
+++ b/infra/import.tf
@@ -77,3 +77,13 @@ import {
   id = "${local.google_project_id}/${var.google_project_location}/piece roles/cloudfunctions.invoker allUsers"
   to = google_cloudfunctions_function_iam_member.piece_invoker
 }
+
+import {
+  id = "projects/${local.google_project_id}/serviceAccounts/cloud-tasks@${local.google_project_id}.iam.gserviceaccount.com"
+  to = google_service_account.cloud_tasks
+}
+
+import {
+  id = "${local.google_project_id} roles/cloudtasks.enqueuer serviceAccount:cloud-tasks@${local.google_project_id}.iam.gserviceaccount.com"
+  to = google_project_iam_member.cloud_tasks_enqueuer
+}

--- a/infra/import.tf
+++ b/infra/import.tf
@@ -87,3 +87,8 @@ import {
   id = "${local.google_project_id} roles/cloudtasks.enqueuer serviceAccount:cloud-tasks@${local.google_project_id}.iam.gserviceaccount.com"
   to = google_project_iam_member.cloud_tasks_enqueuer
 }
+
+import {
+  id = local.google_project_id
+  to = google_app_engine_application.default
+}

--- a/infra/import.tf
+++ b/infra/import.tf
@@ -108,8 +108,8 @@ import {
 }
 
 # import {
-#   id = "projects/${local.google_project_id}-default"
-#   to = google_storage_bucket.default
+#   id = "projects/${local.google_project_id}-deploy"
+#   to = google_storage_bucket.deploy
 # }
 
 import {

--- a/infra/import.tf
+++ b/infra/import.tf
@@ -13,6 +13,11 @@ variable "import_firestore_ruleset_name" {
   description = "Firestore rule set name."
 }
 
+variable "import_firebase_storage_ruleset_name" {
+  type        = string
+  description = "Firebase Storage rule set name."
+}
+
 locals {
   google_project_id = "${var.google_project_id}${var.google_project_id_suffix}"
 }
@@ -114,7 +119,10 @@ import {
   to = google_firebase_storage_bucket.default
 }
 
-# TODO: import to google_firebaserules_ruleset.storage
+import {
+  id = "projects/${local.google_project_id}/rulesets/${var.import_firebase_storage_ruleset_name}"
+  to = google_firebaserules_ruleset.storage
+}
 
 import {
   id = "projects/${local.google_project_id}/releases/firebase.storage/${local.google_project_id}.appspot.com"

--- a/infra/import.tf
+++ b/infra/import.tf
@@ -94,7 +94,7 @@ import {
 }
 
 import {
-  id = "${local.google_project_id}-default"
+  id = "${local.google_project_id}/${local.google_project_id}-default"
   to = google_storage_bucket.default
 }
 

--- a/infra/import.tf
+++ b/infra/import.tf
@@ -47,8 +47,6 @@ import {
   to = google_identity_platform_config.auth
 }
 
-# TODO: import to google_identity_platform_project_default_config.auth
-
 import {
   id = "projects/${local.google_project_id}/databases/(default)"
   to = google_firestore_database.default

--- a/infra/import.tf
+++ b/infra/import.tf
@@ -1,0 +1,29 @@
+variable "firebase_apple_app_id" {
+  type        = string
+  description = "App ID for Firebase Apple app, such as 1:000000000000:ios:xxxxxxxxxxxxxxxxxxxxxx."
+}
+
+variable "firebase_android_app_id" {
+  type        = string
+  description = "App ID for Firebase Android app, such as 1:000000000000:android:xxxxxxxxxxxxxxxxxxxxxx."
+}
+
+import {
+  id = "${var.google_project_id}${var.google_project_id_suffix}"
+  to = google_project.default
+}
+
+import {
+  id = "projects/${var.google_project_id}${var.google_project_id_suffix}"
+  to = google_firebase_project.default
+}
+
+import {
+  id = "projects/${var.google_project_id}${var.google_project_id_suffix}/iosApps/${var.firebase_apple_app_id}"
+  to = google_firebase_apple_app.default
+}
+
+import {
+  id = "projects/${var.google_project_id}${var.google_project_id_suffix}/androidApps/${var.firebase_android_app_id}"
+  to = google_firebase_android_app.default
+}

--- a/infra/import.tf
+++ b/infra/import.tf
@@ -48,3 +48,32 @@ import {
 
 # TODO: import to google_firebaserules_release.firestore
 
+import {
+  id = "${local.google_project_id}/${var.google_project_location}/detect"
+  to = google_cloudfunctions_function.detect
+}
+
+import {
+  id = "${local.google_project_id}/${var.google_project_location}/detect roles/cloudfunctions.invoker allUsers"
+  to = google_cloudfunctions_function_iam_member.detect_invoker
+}
+
+import {
+  id = "${local.google_project_id}/${var.google_project_location}/submit"
+  to = google_cloudfunctions_function.submit
+}
+
+import {
+  id = "${local.google_project_id}/${var.google_project_location}/submit roles/cloudfunctions.invoker allUsers"
+  to = google_cloudfunctions_function_iam_member.submit_invoker
+}
+
+import {
+  id = "${local.google_project_id}/${var.google_project_location}/piece"
+  to = google_cloudfunctions_function.piece
+}
+
+import {
+  id = "${local.google_project_id}/${var.google_project_location}/piece roles/cloudfunctions.invoker allUsers"
+  to = google_cloudfunctions_function_iam_member.piece_invoker
+}

--- a/infra/import.tf
+++ b/infra/import.tf
@@ -39,3 +39,12 @@ import {
 
 # TODO: import to google_identity_platform_project_default_config.auth
 
+import {
+  id = "projects/${local.google_project_id}/databases/(default)"
+  to = google_firestore_database.default
+}
+
+# TODO: import to google_firebaserules_ruleset.firestore
+
+# TODO: import to google_firebaserules_release.firestore
+

--- a/infra/import.tf
+++ b/infra/import.tf
@@ -1,11 +1,16 @@
-variable "firebase_apple_app_id" {
+variable "import_firebase_apple_app_id" {
   type        = string
   description = "App ID for Firebase Apple app, such as 1:000000000000:ios:xxxxxxxxxxxxxxxxxxxxxx."
 }
 
-variable "firebase_android_app_id" {
+variable "import_firebase_android_app_id" {
   type        = string
   description = "App ID for Firebase Android app, such as 1:000000000000:android:xxxxxxxxxxxxxxxxxxxxxx."
+}
+
+variable "import_firestore_ruleset_name" {
+  type        = string
+  description = "Firestore rule set name."
 }
 
 locals {
@@ -23,12 +28,12 @@ import {
 }
 
 import {
-  id = "projects/${local.google_project_id}/iosApps/${var.firebase_apple_app_id}"
+  id = "projects/${local.google_project_id}/iosApps/${var.import_firebase_apple_app_id}"
   to = google_firebase_apple_app.default
 }
 
 import {
-  id = "projects/${local.google_project_id}/androidApps/${var.firebase_android_app_id}"
+  id = "projects/${local.google_project_id}/androidApps/${var.import_firebase_android_app_id}"
   to = google_firebase_android_app.default
 }
 
@@ -44,7 +49,10 @@ import {
   to = google_firestore_database.default
 }
 
-# TODO: import to google_firebaserules_ruleset.firestore
+import {
+  id = "projects/${local.google_project_id}/rulesets/${var.import_firestore_ruleset_name}"
+  to = google_firebaserules_ruleset.firestore
+}
 
 import {
   id = "projects/${local.google_project_id}/releases/cloud.firestore"
@@ -96,10 +104,10 @@ import {
   to = google_app_engine_application.default
 }
 
-import {
-  id = "projects/${local.google_project_id}-default"
-  to = google_storage_bucket.default
-}
+# import {
+#   id = "projects/${local.google_project_id}-default"
+#   to = google_storage_bucket.default
+# }
 
 import {
   id = "projects/${local.google_project_id}/buckets/${local.google_project_id}.appspot.com"
@@ -108,7 +116,10 @@ import {
 
 # TODO: import to google_firebaserules_ruleset.storage
 
-# TODO: import to google_firebaserules_release.storage
+import {
+  id = "projects/${local.google_project_id}/releases/firebase.storage/${local.google_project_id}.appspot.com"
+  to = google_firebaserules_release.storage
+}
 
 import {
   id = "projects/${local.google_project_id}/locations/${var.google_project_location}/queues/${local.google_project_id}-service"

--- a/infra/import.tf
+++ b/infra/import.tf
@@ -8,22 +8,34 @@ variable "firebase_android_app_id" {
   description = "App ID for Firebase Android app, such as 1:000000000000:android:xxxxxxxxxxxxxxxxxxxxxx."
 }
 
+locals {
+  google_project_id = "${var.google_project_id}${var.google_project_id_suffix}"
+}
+
 import {
-  id = "${var.google_project_id}${var.google_project_id_suffix}"
+  id = local.google_project_id
   to = google_project.default
 }
 
 import {
-  id = "projects/${var.google_project_id}${var.google_project_id_suffix}"
+  id = "projects/${local.google_project_id}"
   to = google_firebase_project.default
 }
 
 import {
-  id = "projects/${var.google_project_id}${var.google_project_id_suffix}/iosApps/${var.firebase_apple_app_id}"
+  id = "projects/${local.google_project_id}/iosApps/${var.firebase_apple_app_id}"
   to = google_firebase_apple_app.default
 }
 
 import {
-  id = "projects/${var.google_project_id}${var.google_project_id_suffix}/androidApps/${var.firebase_android_app_id}"
+  id = "projects/${local.google_project_id}/androidApps/${var.firebase_android_app_id}"
   to = google_firebase_android_app.default
 }
+
+import {
+  id = local.google_project_id
+  to = google_identity_platform_config.auth
+}
+
+# TODO: import to google_identity_platform_project_default_config.auth
+

--- a/infra/import.tf
+++ b/infra/import.tf
@@ -97,7 +97,7 @@ import {
 }
 
 import {
-  id = "${local.google_project_id}/${local.google_project_id}-default"
+  id = "projects/${local.google_project_id}-default"
   to = google_storage_bucket.default
 }
 

--- a/infra/import.tf
+++ b/infra/import.tf
@@ -46,10 +46,8 @@ import {
 
 # TODO: import to google_firebaserules_ruleset.firestore
 
-# TODO: import to google_firebaserules_release.firestore
-
 import {
-  id = "projects/${local.google_project_id}/releases/firebase.storage/${local.google_project_id}"
+  id = "projects/${local.google_project_id}/releases/cloud.firestore"
   to = google_firebaserules_release.firestore
 }
 

--- a/infra/import.tf
+++ b/infra/import.tf
@@ -107,10 +107,10 @@ import {
   to = google_app_engine_application.default
 }
 
-# import {
-#   id = "projects/${local.google_project_id}-deploy"
-#   to = google_storage_bucket.deploy
-# }
+import {
+  id = "projects/${local.google_project_id}-deploy"
+  to = google_storage_bucket.deploy
+}
 
 import {
   id = "projects/${local.google_project_id}/buckets/${local.google_project_id}.appspot.com"

--- a/infra/import.tf
+++ b/infra/import.tf
@@ -92,3 +92,17 @@ import {
   id = local.google_project_id
   to = google_app_engine_application.default
 }
+
+import {
+  id = "${local.google_project_id}-default"
+  to = google_storage_bucket.default
+}
+
+import {
+  id = "projects/${local.google_project_id}/buckets/${local.google_project_id}.appspot.com"
+  to = google_firebase_storage_bucket.default
+}
+
+# TODO: import to google_firebaserules_ruleset.storage
+
+# TODO: import to google_firebaserules_release.storage

--- a/infra/import.tf
+++ b/infra/import.tf
@@ -49,6 +49,11 @@ import {
 # TODO: import to google_firebaserules_release.firestore
 
 import {
+  id = "projects/${local.google_project_id}/releases/firebase.storage/${local.google_project_id}"
+  to = google_firebaserules_release.firestore
+}
+
+import {
   id = "${local.google_project_id}/${var.google_project_location}/detect"
   to = google_cloudfunctions_function.detect
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -51,9 +51,7 @@ resource "google_project" "default" {
   project_id      = "colomney-my-pet-melody${var.google_project_id_suffix}"
   billing_account = var.google_billing_account_id
 
-  labels = {
-    "firebase" = "enabled"
-  }
+  labels = {}
 }
 
 resource "google_project_service" "default" {
@@ -89,7 +87,7 @@ resource "google_firebase_apple_app" "default" {
   provider = google-beta
 
   project      = google_project.default.project_id
-  display_name = "iOS"
+  display_name = "iOS-Dev"
   bundle_id    = "ide.shota.colomney.MyPetMelody${var.application_id_suffix}"
   team_id      = "4UGYN353AH"
 
@@ -102,8 +100,12 @@ resource "google_firebase_android_app" "default" {
   provider = google-beta
 
   project      = google_project.default.project_id
-  display_name = "Android"
+  display_name = "Android-Dev"
   package_name = "ide.shota.colomney.MyPetMelody${var.application_id_suffix}"
+  sha1_hashes = [
+    "9caa5a8af776c9eddfbfe01fbe620c25ad97e9f5",
+    "d8eed8412b16ad696870fc9cea0876dea4cc0aa4",
+  ]
 
   depends_on = [
     google_firebase_project.default,

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -87,14 +87,15 @@ resource "google_project_service" "default" {
   project  = google_project.default.project_id
   for_each = toset([
     "cloudbilling.googleapis.com",
+    "cloudfunctions.googleapis.com",
     "cloudresourcemanager.googleapis.com",
     "cloudtasks.googleapis.com",
     "firebase.googleapis.com",
     "firebaserules.googleapis.com",
     "firebasestorage.googleapis.com",
     "firestore.googleapis.com",
-    "serviceusage.googleapis.com",
     "identitytoolkit.googleapis.com",
+    "serviceusage.googleapis.com",
   ])
   service = each.key
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -60,13 +60,10 @@ terraform {
   }
 }
 
-# Configures the provider to use the resource block's specified project for quota checks.
 provider "google-beta" {
   user_project_override = true
 }
 
-# Configures the provider to not use the resource block's specified project for quota checks.
-# This provider should only be used during project creation and initializing services.
 provider "google-beta" {
   alias                 = "no_user_project_override"
   user_project_override = false
@@ -100,7 +97,6 @@ resource "google_project_service" "default" {
   ])
   service = each.key
 
-  # Don't disable the service if the resource block is removed by accident.
   disable_on_destroy = false
 }
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,6 +1,18 @@
+variable "google_project_id" {
+  type        = string
+  default     = "colomney-my-pet-melody"
+  description = "ID for GCP project."
+}
+
 variable "google_project_id_suffix" {
   type        = string
   description = "ID suffix for GCP project."
+}
+
+variable "google_project_display_name" {
+  type        = string
+  default     = "MyPetMelody"
+  description = "Display name for GCP project."
 }
 
 variable "google_project_display_name_suffix" {
@@ -18,9 +30,25 @@ variable "google_project_location" {
   description = "Location for GCP project."
 }
 
+variable "application_id" {
+  type        = string
+  default     = "ide.shota.colomney.MyPetMelody"
+  description = "Application ID for iOS and Android."
+}
+
 variable "application_id_suffix" {
   type        = string
   description = "Application ID suffix for iOS and Android."
+}
+
+variable "ios_app_team_id" {
+  type        = string
+  description = "Team ID for iOS app."
+}
+
+variable "firebase_android_app_sha1_hashes" {
+  type        = list(string)
+  description = "Allowed SHA-1 hashes for Firebase Android app."
 }
 
 terraform {
@@ -47,8 +75,8 @@ provider "google-beta" {
 resource "google_project" "default" {
   provider = google-beta.no_user_project_override
 
-  name            = "MyPetMelody${var.google_project_display_name_suffix}"
-  project_id      = "colomney-my-pet-melody${var.google_project_id_suffix}"
+  name            = "${var.google_project_display_name}${var.google_project_display_name_suffix}"
+  project_id      = "${var.google_project_id}${var.google_project_id_suffix}"
   billing_account = var.google_billing_account_id
 
   labels = {}
@@ -88,8 +116,8 @@ resource "google_firebase_apple_app" "default" {
 
   project      = google_project.default.project_id
   display_name = "iOS-Dev"
-  bundle_id    = "ide.shota.colomney.MyPetMelody${var.application_id_suffix}"
-  team_id      = "4UGYN353AH"
+  bundle_id    = "${var.application_id}${var.application_id_suffix}"
+  team_id      = var.ios_app_team_id
 
   depends_on = [
     google_firebase_project.default,
@@ -101,11 +129,8 @@ resource "google_firebase_android_app" "default" {
 
   project      = google_project.default.project_id
   display_name = "Android-Dev"
-  package_name = "ide.shota.colomney.MyPetMelody${var.application_id_suffix}"
-  sha1_hashes = [
-    "9caa5a8af776c9eddfbfe01fbe620c25ad97e9f5",
-    "d8eed8412b16ad696870fc9cea0876dea4cc0aa4",
-  ]
+  package_name = "${var.application_id}${var.application_id_suffix}"
+  sha1_hashes = var.firebase_android_app_sha1_hashes
 
   depends_on = [
     google_firebase_project.default,

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -87,6 +87,7 @@ resource "google_project_service" "default" {
   project  = google_project.default.project_id
   for_each = toset([
     "cloudbilling.googleapis.com",
+    "cloudbuild.googleapis.com",
     "cloudfunctions.googleapis.com",
     "cloudresourcemanager.googleapis.com",
     "cloudtasks.googleapis.com",

--- a/infra/service-account.tf
+++ b/infra/service-account.tf
@@ -1,12 +1,36 @@
-resource "google_service_account" "firebase_admin" {
-  project      = google_project.default.project_id
-  account_id   = "firebase-adminsdk-zlkov"
-  display_name = "firebase-adminsdk"
-  description  = "Firebase Admin SDK Service Agent"
-}
+# resource "google_service_account" "firebase_admin" {
+#   project      = google_project.default.project_id
+#   account_id   = "firebase-adminsdk-zlkov"
+#   display_name = "firebase-adminsdk"
+#   description  = "Firebase Admin SDK Service Agent"
+# }
+
+# resource "google_project_iam_member" "firebase_admin_service_agent" {
+#   project = google_project.default.project_id
+#   role    = "roles/firebase.sdkAdminServiceAgent"
+#   member  = "serviceAccount:${google_service_account.firebase_admin.email}"
+# }
+
+# resource "google_project_iam_member" "firebase_admin_auth" {
+#   project = google_project.default.project_id
+#   role    = "roles/firebaseauth.admin"
+#   member  = "serviceAccount:${google_service_account.firebase_admin.email}"
+# }
+
+# resource "google_project_iam_member" "firebase_admin_" {
+#   project = google_project.default.project_id
+#   role    = "roles/firebaseauth.admin"
+#   member  = "serviceAccount:${google_service_account.firebase_admin.email}"
+# }
 
 resource "google_service_account" "cloud_tasks" {
   project      = google_project.default.project_id
   account_id   = "cloud-tasks"
   display_name = "Cloud Tasks"
+}
+
+resource "google_project_iam_member" "cloud_tasks_enqueuer" {
+  project = google_project.default.project_id
+  role    = "roles/cloudtasks.enqueuer"
+  member  = "serviceAccount:${google_service_account.cloud_tasks.email}"
 }

--- a/infra/service-account.tf
+++ b/infra/service-account.tf
@@ -1,0 +1,12 @@
+resource "google_service_account" "firebase_admin" {
+  project      = google_project.default.project_id
+  account_id   = "firebase-adminsdk-zlkov"
+  display_name = "firebase-adminsdk"
+  description  = "Firebase Admin SDK Service Agent"
+}
+
+resource "google_service_account" "cloud_tasks" {
+  project      = google_project.default.project_id
+  account_id   = "cloud-tasks"
+  display_name = "Cloud Tasks"
+}

--- a/infra/service-account.tf
+++ b/infra/service-account.tf
@@ -1,28 +1,3 @@
-# resource "google_service_account" "firebase_admin" {
-#   project      = google_project.default.project_id
-#   account_id   = "firebase-adminsdk-zlkov"
-#   display_name = "firebase-adminsdk"
-#   description  = "Firebase Admin SDK Service Agent"
-# }
-
-# resource "google_project_iam_member" "firebase_admin_service_agent" {
-#   project = google_project.default.project_id
-#   role    = "roles/firebase.sdkAdminServiceAgent"
-#   member  = "serviceAccount:${google_service_account.firebase_admin.email}"
-# }
-
-# resource "google_project_iam_member" "firebase_admin_auth" {
-#   project = google_project.default.project_id
-#   role    = "roles/firebaseauth.admin"
-#   member  = "serviceAccount:${google_service_account.firebase_admin.email}"
-# }
-
-# resource "google_project_iam_member" "firebase_admin_" {
-#   project = google_project.default.project_id
-#   role    = "roles/firebaseauth.admin"
-#   member  = "serviceAccount:${google_service_account.firebase_admin.email}"
-# }
-
 resource "google_service_account" "cloud_tasks" {
   project      = google_project.default.project_id
   account_id   = "cloud-tasks"

--- a/infra/storage.tf
+++ b/infra/storage.tf
@@ -9,20 +9,35 @@ resource "google_app_engine_application" "default" {
 }
 
 resource "google_storage_bucket" "default" {
-  name                        = "colomney-my-pet-melody${var.google_project_id_suffix}-default"
+  name                        = "${google_project.default.project_id}.appspot.com"
   provider                    = google-beta
   project                     = google_project.default.project_id
+  default_event_based_hold    = false
+  enable_object_retention     = false
   location                    = var.google_project_location
   uniform_bucket_level_access = false
+  requester_pays              = false
 
   lifecycle_rule {
     action {
       type = "Delete"
     }
     condition {
-      age            = 1
-      matches_prefix = ["userTemporaryMedia/"]
+      age                                     = 1
+      days_since_custom_time                  = 0
+      days_since_noncurrent_time              = 0
+      matches_prefix                          = ["userTemporaryMedia/"]
+      no_age                                  = false
+      num_newer_versions                      = 0
+      send_days_since_custom_time_if_zero     = false
+      send_days_since_noncurrent_time_if_zero = false
+      send_num_newer_versions_if_zero         = false
+      with_state                              = "ANY"
     }
+  }
+
+  soft_delete_policy {
+    retention_duration_seconds = 604800
   }
 
   depends_on = [

--- a/infra/storage.tf
+++ b/infra/storage.tf
@@ -8,8 +8,8 @@ resource "google_app_engine_application" "default" {
   ]
 }
 
-resource "google_storage_bucket" "default" {
-  name                        = "${google_project.default.project_id}-default"
+resource "google_storage_bucket" "deploy" {
+  name                        = "${google_project.default.project_id}-deploy"
   provider                    = google-beta
   project                     = google_project.default.project_id
   default_event_based_hold    = false

--- a/infra/storage.tf
+++ b/infra/storage.tf
@@ -9,7 +9,7 @@ resource "google_app_engine_application" "default" {
 }
 
 resource "google_storage_bucket" "default" {
-  name                        = "${google_project.default.project_id}.appspot.com"
+  name                        = "${google_project.default.project_id}-default"
   provider                    = google-beta
   project                     = google_project.default.project_id
   default_event_based_hold    = false

--- a/infra/storage.tf
+++ b/infra/storage.tf
@@ -49,7 +49,7 @@ resource "google_storage_bucket" "default" {
 resource "google_firebase_storage_bucket" "default-bucket" {
   provider  = google-beta
   project   = google_project.default.project_id
-  bucket_id = google_app_engine_application.default.id
+  bucket_id = google_app_engine_application.default.default_bucket
 
   depends_on = [
     google_app_engine_application.default,

--- a/infra/storage.tf
+++ b/infra/storage.tf
@@ -45,8 +45,7 @@ resource "google_storage_bucket" "default" {
   ]
 }
 
-# Makes the default Storage bucket accessible for Firebase SDKs, authentication, and Firebase Security Rules.
-resource "google_firebase_storage_bucket" "default-bucket" {
+resource "google_firebase_storage_bucket" "default" {
   provider  = google-beta
   project   = google_project.default.project_id
   bucket_id = google_app_engine_application.default.default_bucket
@@ -56,7 +55,6 @@ resource "google_firebase_storage_bucket" "default-bucket" {
   ]
 }
 
-# Creates a ruleset of Cloud Storage Security Rules from a local file.
 resource "google_firebaserules_ruleset" "storage" {
   provider = google-beta
   project  = google_project.default.project_id
@@ -67,14 +65,12 @@ resource "google_firebaserules_ruleset" "storage" {
     }
   }
 
-  # Wait for the default Storage bucket to be provisioned before creating this ruleset.
   depends_on = [
     google_firebase_project.default,
   ]
 }
 
-# Releases the ruleset to the default Storage bucket.
-resource "google_firebaserules_release" "default-bucket" {
+resource "google_firebaserules_release" "storage" {
   provider     = google-beta
   name         = "firebase.storage/${google_app_engine_application.default.default_bucket}"
   ruleset_name = "projects/${google_project.default.project_id}/rulesets/${google_firebaserules_ruleset.storage.name}"

--- a/infra/storage.tf
+++ b/infra/storage.tf
@@ -49,10 +49,10 @@ resource "google_storage_bucket" "default" {
 resource "google_firebase_storage_bucket" "default-bucket" {
   provider  = google-beta
   project   = google_project.default.project_id
-  bucket_id = google_storage_bucket.default.id
+  bucket_id = google_app_engine_application.default.id
 
   depends_on = [
-    google_storage_bucket.default,
+    google_app_engine_application.default,
   ]
 }
 

--- a/infra/task-queue.tf
+++ b/infra/task-queue.tf
@@ -1,11 +1,11 @@
 provider "google" {
-  project     = "colomney-my-pet-melody${var.google_project_id_suffix}"
+  project     = google_project.default.project_id
   region      = var.google_project_location
   credentials = file("google-cloud-credentials.json")
 }
 
 resource "google_cloud_tasks_queue" "advanced_configuration" {
-  name     = "colomney-my-pet-melody${var.google_project_id_suffix}-service"
+  name     = "${google_project.default.project_id}-service"
   location = var.google_project_location
 
   rate_limits {

--- a/infra/task-queue.tf
+++ b/infra/task-queue.tf
@@ -1,10 +1,4 @@
-provider "google" {
-  project     = google_project.default.project_id
-  region      = var.google_project_location
-  credentials = file("google-cloud-credentials.json")
-}
-
-resource "google_cloud_tasks_queue" "advanced_configuration" {
+resource "google_cloud_tasks_queue" "default" {
   name     = "${google_project.default.project_id}-service"
   location = var.google_project_location
 

--- a/infra/task-queue.tf
+++ b/infra/task-queue.tf
@@ -1,4 +1,5 @@
 resource "google_cloud_tasks_queue" "default" {
+  project = google_project.default.project_id
   name     = "${google_project.default.project_id}-service"
   location = var.google_project_location
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated `.gitignore` to exclude `/function2`.
  - Added `/function.zip` to `.gitignore` in the `infra` directory.
  
- **Infrastructure Updates**
  - Updated Terraform provider versions and hashes in `infra/.terraform.lock.hcl`.
  - Adjusted settings for Google Firestore database protection and deletion policies.
  - Added new Terraform configurations for Google Cloud Functions in `infra/function.tf`.
  - Introduced variables and imports for Firebase configurations in `infra/import.tf`.
  - Updated display names and authentication settings for Firebase apps in `infra/main.tf`.
  - Created Google service accounts for Firebase Admin SDK and Cloud Tasks in `infra/service-account.tf`.
  - Enhanced storage bucket configurations with new attributes and lifecycle rules in `infra/storage.tf`.
  - Updated project and queue names in the task queue configuration in `infra/task-queue.tf`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->