### PR TITLE
ci: reduce CI frequency for develop infra

### DIFF
--- a/.github/workflows/cd_regular-release-infra-develop.yml
+++ b/.github/workflows/cd_regular-release-infra-develop.yml
@@ -2,7 +2,7 @@ name: CD / Regular release for infrastructure Develop
 
 on:
   schedule:
-    - cron: '0 23 * * *' # 08:00 JST every day
+    - cron: '0 23 * * 4' # 08:00 JST every Friday
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the schedule for Continuous Deployment to run every Friday at 8:00 AM JST instead of daily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->