### PR TITLE
ci: ungroup freezed and freezed_annotation for PRs by Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,10 +32,6 @@
       "groupName": "cloud_firestore"
     },
     {
-      "matchPackageNames": ["freezed", "freezed_annotation"],
-      "groupName": "freezed"
-    },
-    {
       "matchManagers": ["pub"],
       "matchPackageNames": ["collection", "dart"],
       "enabled": false
@@ -57,7 +53,7 @@
       "automerge": true
     }
   ],
-  "prConcurrentLimit": 2,
+  "prConcurrentLimit": 1,
   "rangeStrategy": "pin",
   "reviewers": ["shotaIDE"]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration to adjust the number of concurrent pull requests from 2 to 1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->