### PR TITLE
ci: group firebase_auth as firebase when updating dependencies by Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,7 +28,11 @@
       "automerge": true
     },
     {
-      "matchPackageNames": ["cloud_firestore", "firebase_core"],
+      "matchPackageNames": [
+        "cloud_firestore",
+        "firebase_auth",
+        "firebase_core"
+      ],
       "groupName": "cloud_firestore"
     },
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency management to include `firebase_auth` under `cloud_firestore`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->