### PR TITLE
ci: group firebase_crashlytics as firebase when updating dependencies by Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,7 +31,8 @@
       "matchPackageNames": [
         "cloud_firestore",
         "firebase_auth",
-        "firebase_core"
+        "firebase_core",
+        "firebase_crashlytics"
       ],
       "groupName": "cloud_firestore"
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added `"firebase_crashlytics"` to the list of managed packages under the `cloud_firestore` group for dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->