### PR TITLE
ci: group firebase libraries when updating dependencies by Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,11 +30,14 @@
     {
       "matchPackageNames": [
         "cloud_firestore",
+        "firebase_analytics",
         "firebase_auth",
         "firebase_core",
-        "firebase_crashlytics"
+        "firebase_crashlytics",
+        "firebase_messaging",
+        "firebase_remote_config"
       ],
-      "groupName": "cloud_firestore"
+      "groupName": "firebase"
     },
     {
       "matchManagers": ["pub"],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `renovate.json` to include `firebase_analytics`, `firebase_messaging`, and `firebase_remote_config` packages under the `firebase` group.
  - Consolidated the `cloud_firestore` group into the `firebase` group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->