### PR TITLE
fix: Japanese metadata localization outside of Japan

### DIFF
--- a/lib/data/service/database_service.dart
+++ b/lib/data/service/database_service.dart
@@ -34,11 +34,14 @@ final templateDraftsProvider = StreamProvider(
 final localizedTemplateMetadataListProvider =
     StreamProvider.family<List<LocalizedTemplateMetadata>, Locale>(
   (_, locale) {
-    final languageTag = locale.toLanguageTag();
+    // Currently, we only care about the language code.
+    // When we need to support languages varies by region,
+    // we should consider the country code as well.
+    final languageCode = locale.languageCode;
 
     return FirebaseFirestore.instance
         .collection('localized')
-        .doc(languageTag)
+        .doc(languageCode)
         .collection('systemMedia')
         .snapshots()
         .map(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated locale handling to use language code only for data retrieval, preparing for future support of region-specific languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->