### PR TITLE
ci: migrate pip dependencies updating from dependabot to Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,12 +18,3 @@ updates:
       interval: "daily"
       time: "05:00"
       timezone: "Asia/Tokyo"
-  - package-ecosystem: "pip"
-    directory: "/function/"
-    open-pull-requests-limit: 1
-    reviewers:
-      - "shotaIDE"
-    schedule:
-      interval: "daily"
-      time: "06:00"
-      timezone: "Asia/Tokyo"

--- a/renovate.json
+++ b/renovate.json
@@ -2,13 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "enabledManagers": [
     "asdf",
+    "github-actions",
     "gradle-wrapper",
-    "pyenv",
+    "pip_requirements",
     "pub",
+    "pyenv",
     "ruby-version",
-    "terraform",
     "terraform-version",
-    "github-actions"
+    "terraform"
   ],
   "extends": ["config:best-practices"],
   "labels": ["dependencies"],
@@ -21,6 +22,11 @@
     {
       "matchManagers": ["gradle-wrapper"],
       "addLabels": ["gradle"],
+      "automerge": true
+    },
+    {
+      "matchManagers": ["pip_requirements"],
+      "addLabels": ["python"],
       "automerge": true
     },
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed configuration for the "pip" package ecosystem from Dependabot settings, streamlining dependency management.
  - Enhanced the Renovate configuration to include support for "github-actions" and "pip_requirements", improving automation and efficiency in managing Python and other dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->